### PR TITLE
fix: Fixed the auto news posting from from repeating articles

### DIFF
--- a/src/utils/articleTracker.ts
+++ b/src/utils/articleTracker.ts
@@ -1,0 +1,94 @@
+import logger from "./logger.js";
+
+/**
+ * Represents a posted article record.
+ */
+interface PostedArticle {
+    url: string;
+    title: string;
+    postedAt: Date;
+}
+
+/**
+ * Simple in-memory tracker for the last 10 posted articles to prevent duplicates.
+ * Uses a rolling queue to maintain only the most recent articles.
+ */
+class ArticleTracker {
+    /** Queue of the last 10 posted articles */
+    private postedArticles: PostedArticle[] = [];
+    /** Maximum number of articles to track */
+    private readonly maxTrackedArticles = 10;
+
+    /**
+     * Checks if an article has already been posted in the last 10 articles.
+     * @param {string} url - The article URL to check.
+     * @returns {boolean} True if the article has been posted recently.
+     */
+    public hasBeenPosted(url: string): boolean {
+        const cleanUrl = this.cleanUrl(url);
+        return this.postedArticles.some(article => this.cleanUrl(article.url) === cleanUrl);
+    }
+
+    /**
+     * Marks an article as posted and adds it to the tracking queue.
+     * @param {string} url - The article URL.
+     * @param {string} title - The article title.
+     */
+    public markAsPosted(url: string, title: string): void {
+        const cleanUrl = this.cleanUrl(url);
+        const now = new Date();
+
+        // Add new article to the front of the queue
+        this.postedArticles.unshift({
+            url: cleanUrl,
+            title: title,
+            postedAt: now
+        });
+
+        // Keep only the last maxTrackedArticles
+        if (this.postedArticles.length > this.maxTrackedArticles) {
+            this.postedArticles = this.postedArticles.slice(0, this.maxTrackedArticles);
+        }
+
+        logger(`[articleTracker] Added article to tracking: ${title}`, "debug");
+    }
+
+    /**
+     * Gets a list of articles that haven't been posted recently.
+     * @param {Array<{link: string, title: string, pubDate: string}>} articles - Array of articles to filter.
+     * @returns {Array<{link: string, title: string, pubDate: string}>} Array of articles that haven't been posted recently.
+     */
+    public filterNewArticles(articles: Array<{link: string, title: string, pubDate: string}>): Array<{link: string, title: string, pubDate: string}> {
+        return articles.filter(article => !this.hasBeenPosted(article.link));
+    }
+
+    /**
+     * Cleans a URL for consistent storage and comparison.
+     * @param {string} url - The URL to clean.
+     * @returns {string} The cleaned URL.
+     */
+    private cleanUrl(url: string): string {
+        return url.trim().toLowerCase();
+    }
+
+    /**
+     * Gets the number of articles currently tracked.
+     * @returns {number} The number of tracked articles.
+     */
+    public get trackedCount(): number {
+        return this.postedArticles.length;
+    }
+
+    /**
+     * Gets a list of recently posted articles (for debugging).
+     * @returns {Array<{title: string, postedAt: Date}>} Array of recent articles.
+     */
+    public getRecentArticles(): Array<{title: string, postedAt: Date}> {
+        return this.postedArticles.map(article => ({
+            title: article.title,
+            postedAt: article.postedAt
+        }));
+    }
+}
+
+export default new ArticleTracker();

--- a/src/utils/newsPoster.ts
+++ b/src/utils/newsPoster.ts
@@ -2,6 +2,7 @@ import { Client, EmbedBuilder, TextChannel } from "discord.js";
 import config from "../config/config.js";
 import { fetchLatestNews, isCriticalNews } from "../lib/hnNews.js";
 import logger from "./logger.js";
+import articleTracker from "./articleTracker.js";
 
 /**
  * Posts the latest news articles to the configured Discord channel.
@@ -24,23 +25,37 @@ export async function postNews(client: Client, isCritical: boolean = false): Pro
             return;
         }
 
-        // Fetch latest news
-        const articles = await fetchLatestNews(isCritical ? 1 : 3);
+        // Fetch a large batch of articles to find enough new ones
+        const targetCount = isCritical ? 1 : 3;
+        const fetchCount = Math.max(targetCount * 5, 25); // Fetch 5x what we need, minimum 25
+        
+        const articles = await fetchLatestNews(fetchCount);
         if (articles.length === 0) {
             logger("[newsPoster] No articles to post", "warn");
             return;
         }
 
+        // Filter out articles that have been posted recently
+        const newArticles = articleTracker.filterNewArticles(articles);
+        
+        if (newArticles.length === 0) {
+            logger("[newsPoster] All fetched articles have been posted recently - RSS feed may be stale", "info");
+            return;
+        }
+
+        // Take only the number of articles we want to post
+        const articlesToPost = newArticles.slice(0, targetCount);
+
         // Create embed
         const embed = new EmbedBuilder()
             .setTitle(isCritical ? "🚨 CRITICAL CYBER NEWS ALERT" : "📰 Latest Cyber News")
             .setColor(isCritical ? 0xff3333 : 0x00aeef)
-            .setDescription(isCritical ? "Critical article from The Hacker News" : `Top ${articles.length} articles from The Hacker News`)
+            .setDescription(isCritical ? "Critical article from The Hacker News" : `Top ${articlesToPost.length} articles from The Hacker News`)
             .setFooter({ text: "The Hacker News" })
             .setTimestamp();
 
         // Add article fields
-        articles.forEach((article, index) => {
+        articlesToPost.forEach((article, index) => {
             const isCriticalArticle = isCriticalNews(article);
             const prefix = isCriticalArticle ? "🚨 " : "";
             
@@ -53,7 +68,13 @@ export async function postNews(client: Client, isCritical: boolean = false): Pro
 
         // Post to channel
         await channel.send({ embeds: [embed] });
-        logger(`[newsPoster] Posted ${articles.length} articles${isCritical ? " (CRITICAL)" : ""}`, "success");
+        
+        // Mark all posted articles as tracked
+        articlesToPost.forEach(article => {
+            articleTracker.markAsPosted(article.link, article.title);
+        });
+        
+        logger(`[newsPoster] Posted ${articlesToPost.length} articles${isCritical ? " (CRITICAL)" : ""}`, "success");
     } catch (error) {
         logger("[newsPoster] Error posting news: " + String(error), "error");
     }


### PR DESCRIPTION
The bot now fetches 25 articles at 8:30am everyday and keeps track of the last 10 articles posted to compare to whenever preparing to post. If a duplicate is found, it compares the rest of the 25 until a non-duplicate is found to post.

This should eliminate duplicate article posting while still keeping the channel active and community informed.